### PR TITLE
- refactored branch trigger, take 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ local.properties
 Session.vim
 .netrwhist
 *~
+some/

--- a/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/events/impl/GitHubBranchRestrictionFilter.java
+++ b/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/events/impl/GitHubBranchRestrictionFilter.java
@@ -1,0 +1,127 @@
+package com.github.kostyasha.github.integration.branch.events.impl;
+
+import com.github.kostyasha.github.integration.branch.GitHubBranch;
+import com.github.kostyasha.github.integration.branch.GitHubBranchCause;
+import com.github.kostyasha.github.integration.branch.GitHubBranchRepository;
+import com.github.kostyasha.github.integration.branch.GitHubBranchTrigger;
+import com.github.kostyasha.github.integration.branch.events.GitHubBranchEvent;
+import com.github.kostyasha.github.integration.branch.events.GitHubBranchEventDescriptor;
+
+import hudson.Extension;
+import hudson.model.TaskListener;
+
+import org.kohsuke.github.GHBranch;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class GitHubBranchRestrictionFilter extends GitHubBranchEvent {
+
+    private static final String DISPLAY_NAME = "Branch Restrictions";
+
+    private static final String LINE_SEPARATOR = System.lineSeparator();
+    private static final Logger LOGGER = LoggerFactory.getLogger(GitHubBranchRestrictionFilter.class);
+
+    private boolean exclude;
+
+    private boolean matchAsPattern;
+    private Set<String> matchCriteria;
+
+    @DataBoundConstructor
+    public GitHubBranchRestrictionFilter() {
+    }
+
+    public String getMatchCriteria() {
+        return String.join(LINE_SEPARATOR, matchCriteria);
+    }
+
+    public boolean isExclude() {
+        return exclude;
+    }
+
+    public boolean isMatchAsPattern() {
+        return matchAsPattern;
+    }
+
+    @DataBoundSetter
+    public void setExclude(boolean exclude) {
+        this.exclude = exclude;
+    }
+
+    @DataBoundSetter
+    public void setMatchAsPattern(boolean matchAsPattern) {
+        this.matchAsPattern = matchAsPattern;
+    }
+
+    @DataBoundSetter
+    public void setMatchCriteria(String matchCriteria) {
+        this.matchCriteria = Stream.of(matchCriteria
+                .split(LINE_SEPARATOR))
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public GitHubBranchCause check(GitHubBranchTrigger gitHubBranchTrigger, GHBranch remoteBranch, GitHubBranch localBranch,
+            GitHubBranchRepository localRepo, TaskListener listener) {
+        String name = remoteBranch.getName();
+        if (matchCriteria.isEmpty() || branchIsAllowed(name)) {
+            if (matchCriteria.isEmpty()) {
+                LOGGER.warn("Branch restriction filter added but no match criteria set, all branches allowed");
+            }
+            return toCause(remoteBranch, localRepo, false, "Branch [%s] allowed by branch name restriction filter", name);
+        }
+
+        return toCause(remoteBranch, localRepo, true, "Branch [%s] filtered by branch name restriction filter", name);
+    }
+
+    private boolean branchIsAllowed(String name) {
+        for (String pattern : matchCriteria) {
+            LOGGER.trace("Checking branch [{}] against pattern [{}] - exclude [{}]", name, pattern, exclude);
+            if (matches(name, pattern)) {
+                if (exclude) {
+                    LOGGER.debug("Branch [{}] matches pattern [{}], will be excluded", name, pattern);
+                    return false;
+                }
+                LOGGER.debug("Branch [%s] matched pattern [{}] and is marked for inclusion", name, pattern);
+                return true;
+            }
+        }
+        LOGGER.trace("Branch [{}] matched no patterns, included [{}]", name, exclude);
+        return exclude;
+    }
+
+    private boolean matches(String name, String pattern) {
+        if (!matchAsPattern) {
+            LOGGER.debug("Checking branch [{}] against exact match [{}]", name, pattern);
+            return name.equals(pattern);
+        }
+
+        try {
+            LOGGER.debug("Checking branch [{}] against pattern [{}].", name, pattern);
+            return Pattern.compile(pattern).matcher(name).matches();
+        } catch (PatternSyntaxException e) {
+            LOGGER.error("Invalid pattern [{}] detected checking branch [{}]", pattern, name, e);
+            return false;
+        }
+    }
+
+    private GitHubBranchCause toCause(GHBranch remoteBranch, GitHubBranchRepository localRepo, boolean skip, String message,
+            Object... args) {
+        return new GitHubBranchCause(remoteBranch, localRepo, String.format(message, args), skip);
+    }
+
+    @Extension
+    public static class Descriptor extends GitHubBranchEventDescriptor {
+        @Override
+        public String getDisplayName() {
+            return DISPLAY_NAME;
+        }
+    }
+}

--- a/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/trigger/check/LocalRepoUpdater.java
+++ b/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/trigger/check/LocalRepoUpdater.java
@@ -1,11 +1,12 @@
 package com.github.kostyasha.github.integration.branch.trigger.check;
 
 import com.github.kostyasha.github.integration.branch.GitHubBranchRepository;
-import com.google.common.base.Function;
 import com.github.kostyasha.github.integration.branch.GitHubBranch;
 import org.kohsuke.github.GHBranch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.function.Function;
 
 /**
  * @author Kanstantsin Shautsou
@@ -24,6 +25,7 @@ public class LocalRepoUpdater implements Function<GHBranch, GHBranch> {
 
     @Override
     public GHBranch apply(GHBranch remoteBranch) {
+        LOGGER.trace("Updating local branch repository with [{}]", remoteBranch.getName());
         localRepo.getBranches().put(remoteBranch.getName(), new GitHubBranch(remoteBranch));
 
         return remoteBranch;

--- a/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/trigger/check/SkipFirstRunForBranchFilter.java
+++ b/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/trigger/check/SkipFirstRunForBranchFilter.java
@@ -1,8 +1,10 @@
 package com.github.kostyasha.github.integration.branch.trigger.check;
 
-import com.google.common.base.Predicate;
+
 import org.jenkinsci.plugins.github.pullrequest.utils.LoggingTaskListenerWrapper;
 import org.kohsuke.github.GHBranch;
+
+import java.util.function.Predicate;
 
 /**
  * @author Kanstantsin Shautsou
@@ -21,7 +23,7 @@ public class SkipFirstRunForBranchFilter implements Predicate<GHBranch> {
     }
 
     @Override
-    public boolean apply(GHBranch remoteBranch) {
+    public boolean test(GHBranch remoteBranch) {
         if (skipFirstRun) {
             logger.info("Skipping first run for branch '{}'", remoteBranch.getName());
             return false;

--- a/github-pullrequest-plugin/src/main/resources/com/github/kostyasha/github/integration/branch/GitHubBranchTrigger/config.groovy
+++ b/github-pullrequest-plugin/src/main/resources/com/github/kostyasha/github/integration/branch/GitHubBranchTrigger/config.groovy
@@ -43,8 +43,9 @@ f.block {
             )
         }
 
-        f.optionalProperty(title: "Experimental: User Restriction", field: "userRestriction")
+        // disable until it's working otherwise ppl will think it is
+        //f.optionalProperty(title: "Experimental: User Restriction", field: "userRestriction")
+        //f.optionalProperty(title: "Experimental: Branch Restriction", field: "branchRestriction")
 
-        f.optionalProperty(title: "Experimental: Branch Restriction", field: "branchRestriction")
     }
 }

--- a/github-pullrequest-plugin/src/main/resources/com/github/kostyasha/github/integration/branch/events/impl/GitHubBranchRestrictionFilter/config.groovy
+++ b/github-pullrequest-plugin/src/main/resources/com/github/kostyasha/github/integration/branch/events/impl/GitHubBranchRestrictionFilter/config.groovy
@@ -1,0 +1,20 @@
+package com.github.kostyasha.github.integration.branch.events.impl.GitHubBranchRestrictionFilter
+
+import lib.FormTagLib
+import lib.LayoutTagLib
+
+def l = namespace(LayoutTagLib);
+def f = namespace(FormTagLib);
+def j = namespace("jelly:core");
+
+f.entry(field: "exclude", title: "Exclude branches that match criteria?") {
+    f.checkbox()
+}
+
+f.entry(field: "matchAsPattern", title: "Match branches against pattern criteria?") {
+    f.checkbox()
+}
+
+f.entry(title: "Branch Names or Patterns") {
+    f.textarea(field: "matchCriteria")
+}

--- a/github-pullrequest-plugin/src/test/java/com/github/kostyasha/github/integration/branch/events/impl/GitHubBranchRestrictionFilterTest.java
+++ b/github-pullrequest-plugin/src/test/java/com/github/kostyasha/github/integration/branch/events/impl/GitHubBranchRestrictionFilterTest.java
@@ -1,0 +1,151 @@
+package com.github.kostyasha.github.integration.branch.events.impl;
+
+import com.github.kostyasha.github.integration.branch.GitHubBranch;
+import com.github.kostyasha.github.integration.branch.GitHubBranchCause;
+import com.github.kostyasha.github.integration.branch.GitHubBranchRepository;
+import com.github.kostyasha.github.integration.branch.GitHubBranchTrigger;
+import com.github.kostyasha.github.integration.branch.events.impl.GitHubBranchRestrictionFilter;
+
+import org.jenkinsci.plugins.github.pullrequest.utils.LoggingTaskListenerWrapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.kohsuke.github.GHBranch;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+public class GitHubBranchRestrictionFilterTest {
+
+    private static final String BRANCH1 = "branch1";
+    private static final String BRANCH2 = "branch2";
+    private static final String BRANCH3 = "3branch";
+
+    private static final String MASTER = "master";
+    private static final String OTHER = "other";
+
+    private static final String PATTERN1 = "\\w+\\d+";
+    private static final String PATTERN2 = "\\d+\\w+";
+
+    private GitHubBranchRestrictionFilter filter;
+
+    @Mock
+    private GHBranch mockRemoteBranch;
+
+    @Mock
+    private GitHubBranchRepository mockRepo;
+
+    @Mock
+    private GitHubBranch mockLocalBranch;
+
+    @Mock
+    private GitHubBranchTrigger mockTrigger;
+
+    @Mock
+    private LoggingTaskListenerWrapper mockPollingLog;
+
+    private GitHubBranchCause result;
+
+    @Before
+    public void before() {
+        MockitoAnnotations.initMocks(this);
+        filter = new GitHubBranchRestrictionFilter();
+    }
+
+    @Test
+    public void testBranchNameExclude() {
+        givenMatchAsExact();
+        givenRestrictionsShouldExclude();
+
+        givenRemoteBranchName(MASTER);
+        whenApplyBranchFilter();
+        thenBranchWasFiltered();
+
+        givenRemoteBranchName(OTHER);
+        whenApplyBranchFilter();
+        thenBranchWasNotFiltered();
+    }
+
+    @Test
+    public void testBranchNameInclude() {
+        givenMatchAsExact();
+
+        givenRemoteBranchName(MASTER);
+        whenApplyBranchFilter();
+        thenBranchWasNotFiltered();
+
+        givenRemoteBranchName(OTHER);
+        whenApplyBranchFilter();
+        thenBranchWasFiltered();
+    }
+
+    @Test
+    public void testBranchNamePatternExclude() {
+        givenMatchAsPatterns();
+        givenRestrictionsShouldExclude();
+
+        givenRemoteBranchName(BRANCH1);
+        whenApplyBranchFilter();
+        thenBranchWasFiltered();
+
+        givenRemoteBranchName(BRANCH3);
+        whenApplyBranchFilter();
+        thenBranchWasFiltered();
+
+        givenRemoteBranchName(MASTER);
+        whenApplyBranchFilter();
+        thenBranchWasNotFiltered();
+    }
+
+    @Test
+    public void testBranchNamePatternInclude() {
+        givenMatchAsPatterns();
+
+        givenRemoteBranchName(BRANCH1);
+        whenApplyBranchFilter();
+        thenBranchWasNotFiltered();
+
+        givenRemoteBranchName(BRANCH3);
+        whenApplyBranchFilter();
+        thenBranchWasNotFiltered();
+
+        givenRemoteBranchName(MASTER);
+        whenApplyBranchFilter();
+        thenBranchWasFiltered();
+    }
+
+    private String createTestInput(String... strings) {
+        return String.join(System.lineSeparator(), strings);
+    }
+
+    private void givenMatchAsExact() {
+        filter.setMatchCriteria(createTestInput(MASTER, BRANCH1, BRANCH2, BRANCH3));
+    }
+
+    private void givenMatchAsPatterns() {
+        filter.setMatchAsPattern(true);
+        filter.setMatchCriteria(createTestInput(PATTERN1, PATTERN2));
+    }
+
+    private void givenRemoteBranchName(String name) {
+        when(mockRemoteBranch.getName()).thenReturn(name);
+    }
+
+    private void givenRestrictionsShouldExclude() {
+        filter.setExclude(true);
+    }
+
+    private void thenBranchWasFiltered() {
+        assertTrue("buildable filtered", result.isSkip());
+    }
+
+    private void thenBranchWasNotFiltered() {
+        assertFalse("buildable not filtered", result.isSkip());
+    }
+
+    private void whenApplyBranchFilter() {
+        result = filter.check(mockTrigger, mockRemoteBranch, mockLocalBranch, mockRepo, mockPollingLog);
+    }
+}

--- a/github-pullrequest-plugin/src/test/java/com/github/kostyasha/github/integration/branch/trigger/check/BranchToCauseConverterTest.java
+++ b/github-pullrequest-plugin/src/test/java/com/github/kostyasha/github/integration/branch/trigger/check/BranchToCauseConverterTest.java
@@ -1,0 +1,133 @@
+package com.github.kostyasha.github.integration.branch.trigger.check;
+
+import com.github.kostyasha.github.integration.branch.GitHubBranchCause;
+import com.github.kostyasha.github.integration.branch.GitHubBranchRepository;
+import com.github.kostyasha.github.integration.branch.GitHubBranchTrigger;
+import com.github.kostyasha.github.integration.branch.events.GitHubBranchEvent;
+
+import org.jenkinsci.plugins.github.pullrequest.utils.LoggingTaskListenerWrapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.kohsuke.github.GHBranch;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.github.kostyasha.github.integration.branch.trigger.check.BranchToCauseConverter.toGitHubBranchCause;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class BranchToCauseConverterTest {
+
+    @Mock
+    private GHBranch mockBranch;
+
+    @Mock
+    private GitHubBranchCause mockCause;
+
+    private List<GitHubBranchEvent> mockEvents;
+
+    @Mock
+    private GitHubBranchRepository mockLocalRepo;
+
+    @Mock
+    private LoggingTaskListenerWrapper mockPollingLog;
+
+    @Mock
+    private GitHubBranchTrigger mockTrigger;
+
+    private GitHubBranchCause result;
+
+    @Before
+    public void before() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        when(mockBranch.getName()).thenReturn("branch");
+    }
+
+    @Test
+    public void testErrorCheckingEvent() throws Exception {
+        givenAnEventCheckException();
+        whenMapToCause();
+        thenNoCauseIsFound();
+    }
+
+    @Test
+    public void testEventsMatches() throws Exception {
+        givenAnEventMatches();
+        whenMapToCause();
+        thenACausesIsFound();
+    }
+
+    @Test
+    public void testEventsMatchesButCauseSkipped() throws Exception {
+        givenCauseShouldBeSkipped();
+        givenAnEventMatches();
+        whenMapToCause();
+        thenNoCauseIsFound();
+    }
+
+    @Test
+    public void testNoEventsMatch() throws Exception {
+        givenNoEventsMatch();
+        whenMapToCause();
+        thenNoCauseIsFound();
+    }
+
+    private GitHubBranchEvent createExceptionEvent() throws IOException {
+        GitHubBranchEvent event = mock(GitHubBranchEvent.class);
+        doThrow(IOException.class).when(event).check(any(), any(), any(), any(), any());
+
+        return event;
+    }
+
+    private GitHubBranchEvent createMatchingEvent() throws IOException {
+        GitHubBranchEvent event = mock(GitHubBranchEvent.class);
+        when(event.check(any(), any(), any(), any(), any())).thenReturn(mockCause);
+
+        return event;
+    }
+
+    private GitHubBranchEvent createNonMatchingEvent() throws IOException {
+        GitHubBranchEvent event = mock(GitHubBranchEvent.class);
+        when(event.check(any(), any(), any(), any(), any())).thenReturn(null);
+
+        return event;
+    }
+
+    private void givenAnEventCheckException() throws IOException {
+        mockEvents = Arrays.asList(createNonMatchingEvent(), createExceptionEvent());
+    }
+
+    private void givenAnEventMatches() throws IOException {
+        mockEvents = Arrays.asList(createNonMatchingEvent(), createMatchingEvent());
+    }
+
+    private void givenCauseShouldBeSkipped() {
+        when(mockCause.isSkip()).thenReturn(true);
+    }
+
+    private void givenNoEventsMatch() throws IOException {
+        mockEvents = Arrays.asList(createNonMatchingEvent(), createNonMatchingEvent());
+    }
+
+    private void thenACausesIsFound() {
+        assertNotNull(result);
+    }
+
+    private void thenNoCauseIsFound() {
+        assertNull(result);
+    }
+
+    private void whenMapToCause() {
+        when(mockTrigger.getEvents()).thenReturn(mockEvents);
+        result = toGitHubBranchCause(mockLocalRepo, mockPollingLog, mockTrigger).apply(mockBranch);
+    }
+}

--- a/github-pullrequest-plugin/src/test/java/com/github/kostyasha/github/integration/branch/trigger/check/LocalRepoUpdaterTest.java
+++ b/github-pullrequest-plugin/src/test/java/com/github/kostyasha/github/integration/branch/trigger/check/LocalRepoUpdaterTest.java
@@ -1,0 +1,67 @@
+package com.github.kostyasha.github.integration.branch.trigger.check;
+
+import com.github.kostyasha.github.integration.branch.GitHubBranch;
+import com.github.kostyasha.github.integration.branch.GitHubBranchRepository;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kohsuke.github.GHBranch;
+import org.kohsuke.github.GHRepository;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.net.URL;
+import java.util.Map;
+
+import static com.github.kostyasha.github.integration.branch.trigger.check.LocalRepoUpdater.updateLocalRepo;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class LocalRepoUpdaterTest {
+
+    @Mock
+    private GHBranch mockBranch;
+
+    @Mock
+    private GitHubBranchRepository mockBranchRepo;
+
+    @Mock
+    private GHRepository mockRepo;
+
+    @Mock
+    private Map<String, GitHubBranch> mockMap;
+
+    private LocalRepoUpdater updater;
+
+    @Before
+    public void before() {
+        MockitoAnnotations.initMocks(this);
+        updater = updateLocalRepo(mockBranchRepo);
+    }
+
+    @Test
+    public void testUpdateLocalBranches() throws Exception {
+        givenAGHBranch();
+        whenUpdateRepository();
+        thenBranchWasAdded();
+    }
+
+    private void givenAGHBranch() throws Exception {
+        when(mockRepo.getHtmlUrl()).thenReturn(new URL("http://example.com"));
+
+        when(mockBranch.getName()).thenReturn("branch");
+        when(mockBranch.getOwner()).thenReturn(mockRepo);
+
+        when(mockBranchRepo.getBranches()).thenReturn(mockMap);
+    }
+
+    private void thenBranchWasAdded() {
+        verify(mockBranchRepo).getBranches();
+        verify(mockMap).put(any(), any());
+    }
+
+    private void whenUpdateRepository() {
+        updater.apply(mockBranch);
+    }
+}


### PR DESCRIPTION
replaces #147. 

dsl support will be a separate pull request. i also want to see the `GitHub Branches` page only show branches that match branch name criteria, but that can also happen in another pull request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kostyasha/github-integration-plugin/149)
<!-- Reviewable:end -->
