### PR TITLE
- initial commit message support

### DIFF
--- a/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/dsl/context/events/GitHubBranchCommitChecksDslContext.java
+++ b/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/dsl/context/events/GitHubBranchCommitChecksDslContext.java
@@ -1,0 +1,29 @@
+package com.github.kostyasha.github.integration.branch.dsl.context.events;
+
+
+import com.github.kostyasha.github.integration.branch.events.GitHubBranchCommitCheck;
+import com.github.kostyasha.github.integration.branch.events.impl.GitHubBranchCommitChecks;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javaposse.jobdsl.dsl.Context;
+import javaposse.jobdsl.plugin.ContextExtensionPoint;
+
+public class GitHubBranchCommitChecksDslContext implements Context {
+
+    private GitHubBranchCommitChecks check = new GitHubBranchCommitChecks();
+    private List<GitHubBranchCommitCheck> checks = new ArrayList<>();
+
+    public void commitMessagePattern(Runnable closure) {
+        GitHubBranchCommitMessageCheckDslContext commitContext = new GitHubBranchCommitMessageCheckDslContext();
+        ContextExtensionPoint.executeInContext(closure, commitContext);
+
+        checks.add(commitContext.getCheck());
+    }
+
+    public GitHubBranchCommitChecks getCheck() {
+        check.setChecks(checks);
+        return check;
+    }
+}

--- a/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/dsl/context/events/GitHubBranchCommitMessageCheckDslContext.java
+++ b/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/dsl/context/events/GitHubBranchCommitMessageCheckDslContext.java
@@ -1,0 +1,28 @@
+package com.github.kostyasha.github.integration.branch.dsl.context.events;
+
+import com.github.kostyasha.github.integration.branch.events.impl.GitHubBranchCommitMessageCheck;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import javaposse.jobdsl.dsl.Context;
+
+public class GitHubBranchCommitMessageCheckDslContext implements Context {
+    private static final String LINE_SEPARATOR = System.lineSeparator();
+
+    private final Set<String> matchCriteria = new LinkedHashSet<>();
+    private GitHubBranchCommitMessageCheck event = new GitHubBranchCommitMessageCheck();
+
+    public void excludeMatching() {
+        event.setExclude(true);
+    }
+
+    public void matchCritieria(String matchCritieria) {
+        this.matchCriteria.add(matchCritieria);
+    }
+
+    public GitHubBranchCommitMessageCheck getCheck() {
+        event.setMatchCriteria(String.join(LINE_SEPARATOR, matchCriteria));
+        return event;
+    }
+}

--- a/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/dsl/context/events/GitHubBranchEventsDslContext.java
+++ b/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/dsl/context/events/GitHubBranchEventsDslContext.java
@@ -5,6 +5,7 @@ import com.github.kostyasha.github.integration.branch.events.impl.GitHubBranchCr
 import com.github.kostyasha.github.integration.branch.events.impl.GitHubBranchDeletedEvent;
 import com.github.kostyasha.github.integration.branch.events.impl.GitHubBranchHashChangedEvent;
 import javaposse.jobdsl.dsl.Context;
+import javaposse.jobdsl.plugin.ContextExtensionPoint;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,6 +16,20 @@ import java.util.List;
 public class GitHubBranchEventsDslContext implements Context {
 
     private List<GitHubBranchEvent> events = new ArrayList<>();
+
+    public void branchRestriction(Runnable closure) {
+        GitHubBranchFilterEventDslContext filterContext = new GitHubBranchFilterEventDslContext();
+        ContextExtensionPoint.executeInContext(closure, filterContext);
+
+        events.add(filterContext.getFilter());
+    }
+
+    public void commitChecks(Runnable closure) {
+        GitHubBranchCommitChecksDslContext checksContext = new GitHubBranchCommitChecksDslContext();
+        ContextExtensionPoint.executeInContext(closure, checksContext);
+
+        events.add(checksContext.getCheck());
+    }
 
     public void created() {
         events.add(new GitHubBranchCreatedEvent());
@@ -31,5 +46,4 @@ public class GitHubBranchEventsDslContext implements Context {
     public List<GitHubBranchEvent> events() {
         return events;
     }
-
 }

--- a/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/dsl/context/events/GitHubBranchFilterEventDslContext.java
+++ b/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/dsl/context/events/GitHubBranchFilterEventDslContext.java
@@ -1,0 +1,33 @@
+package com.github.kostyasha.github.integration.branch.dsl.context.events;
+
+import com.github.kostyasha.github.integration.branch.events.impl.GitHubBranchRestrictionFilter;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import javaposse.jobdsl.dsl.Context;
+
+public class GitHubBranchFilterEventDslContext implements Context {
+
+    private static final String LINE_SEPARATOR = System.lineSeparator();
+
+    private final GitHubBranchRestrictionFilter filter = new GitHubBranchRestrictionFilter();
+    private final Set<String> matchCriteria = new LinkedHashSet<>();
+
+    public void excludeMatching() {
+        filter.setExclude(true);
+    }
+
+    public void matchAgainstPatterns() {
+        filter.setMatchAsPattern(true);
+    }
+
+    public void matchCritieria(String matchCritieria) {
+        this.matchCriteria.add(matchCritieria);
+    }
+
+    public GitHubBranchRestrictionFilter getFilter() {
+        filter.setMatchCriteriaStr(String.join(LINE_SEPARATOR, matchCriteria));
+        return filter;
+    }
+}

--- a/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/events/GitHubBranchCommitCheck.java
+++ b/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/events/GitHubBranchCommitCheck.java
@@ -1,0 +1,27 @@
+package com.github.kostyasha.github.integration.branch.events;
+
+import com.github.kostyasha.github.integration.branch.GitHubBranchCause;
+import com.github.kostyasha.github.integration.branch.GitHubBranchRepository;
+
+import hudson.model.AbstractDescribableImpl;
+
+import org.kohsuke.github.GHBranch;
+import org.kohsuke.github.GHCompare.Commit;
+
+public abstract class GitHubBranchCommitCheck extends AbstractDescribableImpl<GitHubBranchCommitCheck> {
+
+    @Override
+    public GitHubBranchCommitCheckDescriptor getDescriptor() {
+        return (GitHubBranchCommitCheckDescriptor) super.getDescriptor();
+    }
+
+    /**
+     * Check used to determine if some associated commit property, such as the commit message, should prevent a build from being triggered.
+     *
+     * @param remoteBranch current branch state from GH.
+     * @param localRepo local repository state.
+     * @param commits commits commits that occurred between the last known local hash and the current remote.
+     * @return <code>GitHubBranchCause</code> instance indicating if the build should be skipped, <code>null</code> otherwise.
+     */
+    public abstract GitHubBranchCause check(GHBranch remoteBranch, GitHubBranchRepository localRepo, Commit[] commits);
+}

--- a/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/events/GitHubBranchCommitCheckDescriptor.java
+++ b/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/events/GitHubBranchCommitCheckDescriptor.java
@@ -1,0 +1,12 @@
+package com.github.kostyasha.github.integration.branch.events;
+
+import hudson.DescriptorExtensionList;
+import hudson.model.Descriptor;
+
+import jenkins.model.Jenkins;
+
+public abstract class GitHubBranchCommitCheckDescriptor extends Descriptor<GitHubBranchCommitCheck> {
+    public static DescriptorExtensionList<GitHubBranchCommitCheck, GitHubBranchCommitCheckDescriptor> all() {
+        return Jenkins.getInstance().getDescriptorList(GitHubBranchCommitCheck.class);
+    }
+}

--- a/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/events/impl/GitHubBranchCommitChecks.java
+++ b/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/events/impl/GitHubBranchCommitChecks.java
@@ -114,7 +114,7 @@ public class GitHubBranchCommitChecks extends GitHubBranchEvent {
         return checks;
     }
 
-    void setChecks(List<GitHubBranchCommitCheck> checks) {
+    public void setChecks(List<GitHubBranchCommitCheck> checks) {
         this.checks = checks;
     }
 

--- a/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/events/impl/GitHubBranchCommitChecks.java
+++ b/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/events/impl/GitHubBranchCommitChecks.java
@@ -1,0 +1,140 @@
+package com.github.kostyasha.github.integration.branch.events.impl;
+
+import com.github.kostyasha.github.integration.branch.GitHubBranch;
+import com.github.kostyasha.github.integration.branch.GitHubBranchCause;
+import com.github.kostyasha.github.integration.branch.GitHubBranchRepository;
+import com.github.kostyasha.github.integration.branch.GitHubBranchTrigger;
+import com.github.kostyasha.github.integration.branch.events.GitHubBranchCommitCheck;
+import com.github.kostyasha.github.integration.branch.events.GitHubBranchCommitCheckDescriptor;
+import com.github.kostyasha.github.integration.branch.events.GitHubBranchEvent;
+import com.github.kostyasha.github.integration.branch.events.GitHubBranchEventDescriptor;
+
+import static org.jenkinsci.plugins.github.pullrequest.utils.ObjectsUtil.isNull;
+
+import hudson.Extension;
+import hudson.model.TaskListener;
+
+import net.sf.json.JSONObject;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.github.GHBranch;
+import org.kohsuke.github.GHCompare;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * This branch event acts as a wrapper around checks that can be performed against commit data that requires an additional round trip to
+ * GitHub to retrieve.
+ * <p>
+ * Commit data is retrieved and then passed to each implementing instance of <code>GitHubBranchCommitCheck</code> to determine information
+ * about the commit should trigger a build.
+ * </p>
+ * <p>
+ * The implementation itself should return a <code>GitHubBranchCause</code> object indicating the build should be skipped, otherwise
+ * it should return <code>null</code>.
+ * </p>
+ *
+ * @author Kanstantsin Shautsou
+ * @author Jae Gangemi
+ */
+public class GitHubBranchCommitChecks extends GitHubBranchEvent {
+    private static final String DISPLAY_NAME = "Commit Checks";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GitHubBranchCommitChecks.class);
+
+    private List<GitHubBranchCommitCheck> checks = new ArrayList<>();
+
+    /**
+     * For groovy UI
+     */
+    @Restricted(value = NoExternalUse.class)
+    public GitHubBranchCommitChecks() {
+    }
+
+    @DataBoundConstructor
+    public GitHubBranchCommitChecks(List<GitHubBranchCommitCheck> checks) {
+        this.checks = checks;
+    }
+
+    @Override
+    public GitHubBranchCause check(GitHubBranchTrigger trigger, GHBranch remoteBranch, @CheckForNull GitHubBranch localBranch,
+            GitHubBranchRepository localRepo, TaskListener listener)
+        throws IOException {
+        if (localBranch == null) {
+            LOGGER.debug("First build of branch [%s] detected.", remoteBranch.getName());
+            return null;
+        }
+
+        GHCompare.Commit[] commits = getComparedCommits(localBranch, remoteBranch);
+        List<GitHubBranchCause> causes = checks.stream()
+                .map(event -> event.check(remoteBranch, localRepo, commits))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        String name = remoteBranch.getName();
+        if (causes.isEmpty()) {
+            LOGGER.debug("Commits for branch [{}] had no effect no triggering build.", name);
+            return null;
+        }
+
+        GitHubBranchCause cause = causes.get(0);
+        LOGGER.info("Building branch [{}] skipped due to commit check: {}", name, cause.getReason());
+
+        return cause;
+    }
+
+    // visible for testing to avoid complex mocking
+    GHCompare.Commit[] getComparedCommits(GitHubBranch localBranch, GHBranch remoteBranch) throws IOException {
+        String previous = localBranch.getCommitSha();
+        String current = remoteBranch.getSHA1();
+
+        LOGGER.debug("Comparing previous hash [{}] with current hash [{}]", previous, current);
+        return remoteBranch.getOwner()
+                .getCompare(previous, current)
+                .getCommits();
+    }
+
+    @Nonnull
+    public List<GitHubBranchCommitCheck> getChecks() {
+        if (isNull(checks)) {
+            checks = new ArrayList<>();
+        }
+        return checks;
+    }
+
+    void setChecks(List<GitHubBranchCommitCheck> checks) {
+        this.checks = checks;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends GitHubBranchEventDescriptor {
+        @Override
+        public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
+            req.bindJSON(this, formData);
+
+            save();
+            return super.configure(req, formData);
+        }
+
+        @Override
+        public final String getDisplayName() {
+            return DISPLAY_NAME;
+        }
+
+        public List<GitHubBranchCommitCheckDescriptor> getEventDescriptors() {
+            return GitHubBranchCommitCheckDescriptor.all();
+        }
+    }
+}

--- a/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/events/impl/GitHubBranchCommitMessageCheck.java
+++ b/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/events/impl/GitHubBranchCommitMessageCheck.java
@@ -1,0 +1,130 @@
+package com.github.kostyasha.github.integration.branch.events.impl;
+
+import com.github.kostyasha.github.integration.branch.GitHubBranchCause;
+import com.github.kostyasha.github.integration.branch.GitHubBranchRepository;
+import com.github.kostyasha.github.integration.branch.events.GitHubBranchCommitCheck;
+import com.github.kostyasha.github.integration.branch.events.GitHubBranchCommitCheckDescriptor;
+import hudson.Extension;
+import org.kohsuke.github.GHBranch;
+import org.kohsuke.github.GHCompare.Commit;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.CheckForNull;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class GitHubBranchCommitMessageCheck extends GitHubBranchCommitCheck {
+    private static final String DISPLAY_NAME = "Commit Message Pattern";
+
+    private static final String LINE_SEPARATOR = System.lineSeparator();
+    private static final Logger LOG = LoggerFactory.getLogger(GitHubBranchCommitMessageCheck.class);
+
+    private boolean exclude;
+
+    private Set<String> matchCriteria;
+
+    @DataBoundConstructor
+    public GitHubBranchCommitMessageCheck() {
+        this.matchCriteria = Collections.emptySet();
+    }
+
+    @Override
+    public GitHubBranchCause check(GHBranch remoteBranch, GitHubBranchRepository localRepo, Commit[] commits) {
+        String name = remoteBranch.getName();
+        if (matchCriteria.isEmpty()) {
+            LOG.warn("Commit message event added but no match criteria set, all commits are allowed.");
+            return null;
+        }
+
+        List<String> messages = Stream.of(commits)
+                .map(commit -> commit.getCommit().getMessage())
+                .collect(Collectors.toList());
+
+        if (commitsAreAllowed(messages)) {
+            LOG.debug("Commit messages {} for branch [{}] allowed, commit ignored.", messages, name);
+            return null;
+        }
+
+        return toCause(remoteBranch, localRepo, true, "Commit messages %s for branch [%s] not allowed by check.", messages, name);
+    }
+
+    public String getMatchCriteria() {
+        return String.join(LINE_SEPARATOR, matchCriteria);
+    }
+
+    public boolean isExclude() {
+        return exclude;
+    }
+
+    @DataBoundSetter
+    public void setExclude(boolean exclude) {
+        this.exclude = exclude;
+    }
+
+    @DataBoundSetter
+    @CheckForNull
+    public void setMatchCriteria(String matchCriteria) {
+        this.matchCriteria = Stream.of(matchCriteria
+                .split(LINE_SEPARATOR))
+                .collect(Collectors.toSet());
+    }
+
+    private boolean commitsAreAllowed(List<String> messages) {
+        boolean allowed = false;
+        for (String message : messages) {
+            if (commitIsAllowed(message)) {
+                allowed = true;
+                break;
+            }
+        }
+        return allowed;
+    }
+
+    private boolean commitIsAllowed(String message) {
+        for (String pattern : matchCriteria) {
+            LOG.debug("Checking commit [{}] against pattern [{}] - exclude [{}]", message, pattern, exclude);
+            if (matches(message, pattern)) {
+                if (exclude) {
+                    LOG.debug("Commit [{}] matches pattern [{}], will be excluded", message, pattern);
+                    return false;
+                }
+                LOG.debug("Commit [{}] matched pattern [{}] and is marked for inclusion", message, pattern);
+                return true;
+            }
+        }
+
+        LOG.debug("Commit [{}] matched no patterns, included [{}]", message, exclude);
+        return exclude;
+    }
+
+    private boolean matches(String message, String pattern) {
+        try {
+            return Pattern.compile(pattern).matcher(message).matches();
+        } catch (PatternSyntaxException e) {
+            LOG.error("Invalid pattern [{}] detected checking commit [{}]", pattern, message, e);
+            return false;
+        }
+    }
+
+    private GitHubBranchCause toCause(GHBranch remoteBranch, GitHubBranchRepository localRepo, boolean skip, String message,
+            Object... args) {
+        return new GitHubBranchCause(remoteBranch, localRepo, String.format(message, args), skip);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends GitHubBranchCommitCheckDescriptor {
+        @Override
+        public final String getDisplayName() {
+            return DISPLAY_NAME;
+        }
+    }
+}

--- a/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/events/impl/GitHubBranchRestrictionFilter.java
+++ b/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/events/impl/GitHubBranchRestrictionFilter.java
@@ -67,6 +67,11 @@ public class GitHubBranchRestrictionFilter extends GitHubBranchEvent {
         this.matchAsPattern = matchAsPattern;
     }
 
+    // visible for testing
+    public Set<String> getMatchCriteria() {
+        return matchCriteria;
+    }
+
     @Override
     public GitHubBranchCause check(GitHubBranchTrigger gitHubBranchTrigger, GHBranch remoteBranch, GitHubBranch localBranch,
                                    GitHubBranchRepository localRepo, TaskListener listener) {
@@ -125,4 +130,5 @@ public class GitHubBranchRestrictionFilter extends GitHubBranchEvent {
             return DISPLAY_NAME;
         }
     }
+
 }

--- a/github-pullrequest-plugin/src/main/resources/com/github/kostyasha/github/integration/branch/events/impl/GitHubBranchCommitChecks/config.groovy
+++ b/github-pullrequest-plugin/src/main/resources/com/github/kostyasha/github/integration/branch/events/impl/GitHubBranchCommitChecks/config.groovy
@@ -1,0 +1,27 @@
+package com.github.kostyasha.github.integration.branch.events.impl.GitHubBranchCommitChecks
+
+import com.github.kostyasha.github.integration.branch.events.impl.GitHubBranchCommitChecks
+
+import groovy.swing.factory.TitledBorderFactory
+import lib.FormTagLib
+import lib.LayoutTagLib
+
+def l = namespace(LayoutTagLib)
+def f = namespace(FormTagLib)
+def j = namespace("jelly:core")
+
+if (instance == null) {
+    instance = new GitHubBranchCommitChecks()
+}
+
+f.block {
+    table(style: 'width:100%; margin-left: 5px;') {
+        f.entry() {
+            f.hetero_list(name: "events",
+                    items: instance.events,
+                    descriptors: descriptor.getEventDescriptors(),
+                    hasHeader: true
+            )
+        }
+    }
+}

--- a/github-pullrequest-plugin/src/main/resources/com/github/kostyasha/github/integration/branch/events/impl/GitHubBranchCommitChecks/config.groovy
+++ b/github-pullrequest-plugin/src/main/resources/com/github/kostyasha/github/integration/branch/events/impl/GitHubBranchCommitChecks/config.groovy
@@ -17,8 +17,8 @@ if (instance == null) {
 f.block {
     table(style: 'width:100%; margin-left: 5px;') {
         f.entry() {
-            f.hetero_list(name: "events",
-                    items: instance.events,
+            f.hetero_list(name: "checks",
+                    items: instance.checks,
                     descriptors: descriptor.getEventDescriptors(),
                     hasHeader: true
             )

--- a/github-pullrequest-plugin/src/main/resources/com/github/kostyasha/github/integration/branch/events/impl/GitHubBranchCommitMessageCheck/config.groovy
+++ b/github-pullrequest-plugin/src/main/resources/com/github/kostyasha/github/integration/branch/events/impl/GitHubBranchCommitMessageCheck/config.groovy
@@ -1,0 +1,16 @@
+package com.github.kostyasha.github.integration.branch.events.impl.GitHubBranchCommitMessageCheck
+
+import lib.FormTagLib
+import lib.LayoutTagLib
+
+def l = namespace(LayoutTagLib);
+def f = namespace(FormTagLib);
+def j = namespace("jelly:core");
+
+f.entry(field: "exclude", title: "Exclude commits that match criteria?") {
+    f.checkbox()
+}
+
+f.entry(title: _("Message Patterns"), field: "matchCriteria") {
+    f.expandableTextbox()
+}

--- a/github-pullrequest-plugin/src/main/resources/com/github/kostyasha/github/integration/branch/events/impl/GitHubBranchCommitMessageCheck/help-matchCriteria.html
+++ b/github-pullrequest-plugin/src/main/resources/com/github/kostyasha/github/integration/branch/events/impl/GitHubBranchCommitMessageCheck/help-matchCriteria.html
@@ -1,0 +1,17 @@
+<div>
+    Inclusion/Exclusion uses pattern matching
+    <br>
+    <br>
+    .*\[maven-release-plugin\].*
+    <br>
+    The example above illustrates that if only revisions with "[maven-release-plugin]" message in first comment line have
+    been committed to the SCM a build will not occur.
+    <br>
+    <br>
+    You can create more complex patterns using embedded flag expressions.
+    <br>
+    <br>
+    (?s).*FOO.*
+    <br>
+    This example will search FOO message in all comment lines.
+</div>

--- a/github-pullrequest-plugin/src/main/resources/com/github/kostyasha/github/integration/branch/events/impl/GitHubBranchCommitMessageCheck/help.html
+++ b/github-pullrequest-plugin/src/main/resources/com/github/kostyasha/github/integration/branch/events/impl/GitHubBranchCommitMessageCheck/help.html
@@ -1,0 +1,8 @@
+<div>
+    If set, the plugin will only build revisions commited with messages that match the pattern. If 'skip' is
+    selected, any revisions with matching messages will be ignored.
+    <br>
+    <br>
+    This can be used to exclude commits done by the build itself from triggering another build, assuming the build
+    server commits the change with a distinct message.
+</div>

--- a/github-pullrequest-plugin/src/test/java/com/github/kostyasha/github/integration/branch/events/impl/GitHubBranchCommitChecksTest.java
+++ b/github-pullrequest-plugin/src/test/java/com/github/kostyasha/github/integration/branch/events/impl/GitHubBranchCommitChecksTest.java
@@ -1,0 +1,129 @@
+package com.github.kostyasha.github.integration.branch.events.impl;
+
+import com.github.kostyasha.github.integration.branch.GitHubBranch;
+import com.github.kostyasha.github.integration.branch.GitHubBranchCause;
+import com.github.kostyasha.github.integration.branch.GitHubBranchRepository;
+import com.github.kostyasha.github.integration.branch.GitHubBranchTrigger;
+import com.github.kostyasha.github.integration.branch.events.GitHubBranchCommitCheck;
+
+import org.jenkinsci.plugins.github.pullrequest.utils.LoggingTaskListenerWrapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.kohsuke.github.GHBranch;
+import org.kohsuke.github.GHCompare;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
+
+public class GitHubBranchCommitChecksTest {
+
+    private GHCompare.Commit[] commits;
+
+    private GitHubBranchCommitChecks check;
+
+    @Mock
+    private GitHubBranchCause mockCause;
+
+    @Mock
+    private GitHubBranchCommitCheck mockCommitCheck;
+
+    @Mock
+    private LoggingTaskListenerWrapper mockListener;
+
+    @Mock
+    private GitHubBranch mockLocalBranch;
+
+    @Mock
+    private GHBranch mockRemoteBranch;
+
+    @Mock
+    private GitHubBranchRepository mockRepo;
+
+    @Mock
+    private GitHubBranchTrigger mockTrigger;
+
+    private GitHubBranchCause result;
+
+    @Before
+    public void before() {
+        MockitoAnnotations.initMocks(this);
+
+        commits = new GHCompare.Commit[0];
+        check = new GitHubBranchCommitChecks(Arrays.asList(mockCommitCheck)) {
+            @Override
+            GHCompare.Commit[] getComparedCommits(GitHubBranch localBranch, GHBranch remoteBranch) throws IOException {
+                return commits;
+            }
+        };
+    }
+
+    @Test
+    public void testBuildIsNotTriggered() throws Exception {
+        givenSkippableBranchCause();
+        whenCheckCommits();
+        thenCheckIsSkipped();
+    }
+
+    @Test
+    public void testCommitChecksReturnNull() throws Exception {
+        givenChecksReturnNull();
+        whenCheckCommits();
+        thenAdditionalTriggersWillBeChecked();
+    }
+
+    @Test
+    public void testCommitsNotConfigured() throws Exception {
+        givenNoChecksAreConfigured();
+        whenCheckCommits();
+        thenAdditionalTriggersWillBeChecked();
+    }
+
+    @Test
+    public void testFirstCommit() throws Exception {
+        givenTheFirstCommit();
+        whenCheckCommits();
+        thenNoCauseReturned();
+    }
+
+    private void givenChecksReturnNull() {
+        when(mockCommitCheck.check(mockRemoteBranch, mockRepo, commits)).thenReturn(null);
+    }
+
+    private void givenNoChecksAreConfigured() {
+        check.setChecks(Collections.emptyList());
+    }
+
+    private void givenSkippableBranchCause() {
+        when(mockCause.isSkip()).thenReturn(true);
+        when(mockCommitCheck.check(mockRemoteBranch, mockRepo, commits)).thenReturn(mockCause);
+    }
+
+    private void givenTheFirstCommit() throws Exception {
+        mockLocalBranch = null;
+    }
+
+    private void thenAdditionalTriggersWillBeChecked() {
+        assertNull(result);
+    }
+
+    private void thenNoCauseReturned()
+    {
+        assertNull("build triggered", result);
+    }
+
+    private void thenCheckIsSkipped() {
+        assertThat("build triggered", result.isSkip(), is(true));
+    }
+
+    private void whenCheckCommits() throws IOException {
+        result = check.check(mockTrigger, mockRemoteBranch, mockLocalBranch, mockRepo, mockListener);
+    }
+}

--- a/github-pullrequest-plugin/src/test/java/com/github/kostyasha/github/integration/branch/events/impl/GitHubBranchCommitMessageCheckTest.java
+++ b/github-pullrequest-plugin/src/test/java/com/github/kostyasha/github/integration/branch/events/impl/GitHubBranchCommitMessageCheckTest.java
@@ -1,0 +1,103 @@
+package com.github.kostyasha.github.integration.branch.events.impl;
+
+import com.github.kostyasha.github.integration.branch.GitHubBranch;
+import com.github.kostyasha.github.integration.branch.GitHubBranchCause;
+import com.github.kostyasha.github.integration.branch.GitHubBranchRepository;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kohsuke.github.GHBranch;
+import org.kohsuke.github.GHCompare.Commit;
+import org.kohsuke.github.GHCompare.InnerCommit;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.when;
+
+public class GitHubBranchCommitMessageCheckTest {
+
+    private static final String PATTERN = ".*\\[maven-release-plugin\\].*";
+
+    private GitHubBranchCommitMessageCheck event;
+
+    @Mock
+    private Commit mockCommit;
+
+    private Commit[] mockCommits;
+
+    @Mock
+    private InnerCommit mockInnerCommit;
+
+    @Mock
+    private GitHubBranch mockLocalBranch;
+
+    @Mock
+    private GHBranch mockRemoteBranch;
+
+    @Mock
+    private GitHubBranchRepository mockRepo;
+
+    private GitHubBranchCause result;
+
+    @Before
+    public void begin() {
+        MockitoAnnotations.initMocks(this);
+        event = new GitHubBranchCommitMessageCheck();
+    }
+
+    @Test
+    public void testExcludeCommit() {
+        givenACommitMessage();
+        givenAMessagePattern();
+        givenMessageShouldBeExcluded();
+        whenEventIsChecked();
+        thenBuildIsSkipped();
+    }
+
+    @Test
+    public void testIncludeCommit() {
+        givenACommitMessage();
+        givenAMessagePattern();
+        whenEventIsChecked();
+        thenCheckHasNoEffect();
+    }
+
+    @Test
+    public void testNoPatternsSpecified() {
+        givenACommitMessage();
+        whenEventIsChecked();
+        thenCheckHasNoEffect();
+    }
+
+    private void givenACommitMessage() {
+        when(mockInnerCommit.getMessage()).thenReturn("commit message");
+        when(mockInnerCommit.getMessage()).thenReturn("[maven-release-plugin] commit message");
+
+        when(mockCommit.getCommit()).thenReturn(mockInnerCommit);
+
+        mockCommits = new Commit[] { mockCommit, mockCommit };
+    }
+
+    private void givenAMessagePattern() {
+        event.setMatchCriteria(PATTERN);
+    }
+
+    private void givenMessageShouldBeExcluded() {
+        event.setExclude(true);
+    }
+
+    private void thenBuildIsSkipped() {
+        assertThat("build triggered", result.isSkip(), equalTo(true));
+    }
+
+    private void thenCheckHasNoEffect() {
+        assertThat("build triggered", result, nullValue());
+    }
+
+    private void whenEventIsChecked() {
+        result = event.check(mockRemoteBranch, mockRepo, mockCommits);
+    }
+}

--- a/github-pullrequest-plugin/src/test/java/org/jenkinsci/plugins/github/pullrequest/dsl/GitHubPRJobDslExtensionTest.java
+++ b/github-pullrequest-plugin/src/test/java/org/jenkinsci/plugins/github/pullrequest/dsl/GitHubPRJobDslExtensionTest.java
@@ -1,26 +1,28 @@
 package org.jenkinsci.plugins.github.pullrequest.dsl;
 
 import com.github.kostyasha.github.integration.branch.GitHubBranchTrigger;
-import hudson.model.Descriptor;
+import com.github.kostyasha.github.integration.branch.events.GitHubBranchEvent;
+import com.github.kostyasha.github.integration.branch.events.impl.GitHubBranchCommitChecks;
+import com.github.kostyasha.github.integration.branch.events.impl.GitHubBranchCommitMessageCheck;
+import com.github.kostyasha.github.integration.branch.events.impl.GitHubBranchRestrictionFilter;
+
 import hudson.model.FreeStyleProject;
-import hudson.tasks.Builder;
-import hudson.tasks.Publisher;
 import hudson.triggers.Trigger;
-import hudson.util.DescribableList;
-import javaposse.jobdsl.plugin.ExecuteDslScripts;
-import javaposse.jobdsl.plugin.LookupStrategy;
-import javaposse.jobdsl.plugin.RemovedJobAction;
-import javaposse.jobdsl.plugin.RemovedViewAction;
+
 import org.apache.commons.io.IOUtils;
-import org.jenkinsci.plugins.github.pullrequest.GitHubPRTrigger;
-import org.jenkinsci.plugins.github.pullrequest.builders.GitHubPRStatusBuilder;
-import org.jenkinsci.plugins.github.pullrequest.publishers.impl.GitHubPRBuildStatusPublisher;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.util.Collection;
 
+import javaposse.jobdsl.plugin.ExecuteDslScripts;
+import javaposse.jobdsl.plugin.LookupStrategy;
+import javaposse.jobdsl.plugin.RemovedJobAction;
+import javaposse.jobdsl.plugin.RemovedViewAction;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
@@ -28,7 +30,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.jenkinsci.plugins.github.pullrequest.GitHubPRTriggerMode.HEAVY_HOOKS_CRON;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 
 /**
  * @author Kanstantsin Shautsou
@@ -72,8 +74,29 @@ public class GitHubPRJobDslExtensionTest {
         assertThat("Should add trigger of GHPR class", trigger, instanceOf(GitHubBranchTrigger.class));
         assertThat("Should have pre status", trigger.isPreStatus(), equalTo(true));
         assertThat("Should have cancel queued", trigger.isCancelQueued(), equalTo(true));
-        assertThat("Should add events", trigger.getEvents(), hasSize(3));
+        assertThat("Should add events", trigger.getEvents(), hasSize(5));
         assertThat("Should set mode", trigger.getTriggerMode(), equalTo(HEAVY_HOOKS_CRON));
+
+        /*
+         * note: this are explicity placed in the first and second positions so it's easier to
+         * pluck them back out for explicit testing
+         */
+        verifyBranchFilter(trigger.getEvents().get(0));
+        verifyCommitChecks(trigger.getEvents().get(1));
     }
 
+    private void verifyCommitChecks(GitHubBranchEvent gitHubBranchEvent) {
+        GitHubBranchCommitChecks commitChecks = (GitHubBranchCommitChecks) gitHubBranchEvent;
+        assertThat("Has commit checks", commitChecks.getChecks(), hasSize(1));
+
+        GitHubBranchCommitMessageCheck messageCheck = (GitHubBranchCommitMessageCheck) commitChecks.getChecks().get(0);
+        assertThat("Has match critiera", messageCheck.getMatchCriteria(), notNullValue());
+    }
+
+    private void verifyBranchFilter(GitHubBranchEvent gitHubBranchEvent) {
+        GitHubBranchRestrictionFilter filter = (GitHubBranchRestrictionFilter) gitHubBranchEvent;
+
+        assertThat("Has branches", filter.getMatchCriteria(), hasSize(2));
+        assertThat("Branches match", filter.getMatchCriteria(), containsInAnyOrder("master", "other"));
+    }
 }

--- a/github-pullrequest-plugin/src/test/resources/dsl/branch-jobdsl.groovy
+++ b/github-pullrequest-plugin/src/test/resources/dsl/branch-jobdsl.groovy
@@ -11,6 +11,22 @@ freeStyleJob('gh-branch') {
                 heavyHooksCron()
             }
             events {
+
+                branchRestriction
+                {
+                    matchCritieria('master')
+                    matchCritieria('other')
+                }
+
+                commitChecks
+                {
+                    commitMessagePattern
+                    {
+                        excludeMatching()
+                        matchCritieria('^(?s)\\[(release|unleash)\\-maven\\-plugin\\].*')
+                    }
+                }
+
                 created()
                 hashChanged()
                 deleted()


### PR DESCRIPTION
i still need to finish the tests and will do that after we sort and implementation issues...

this basically allows events based on commit messages to be added as sub-events to the overall `commit message` event. you stated it was an expensive operation to go back and query the repo, so this allows the query to made once and then each commit event can be its own implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kostyasha/github-integration-plugin/161)
<!-- Reviewable:end -->
