### PR TITLE
Change log message to show that the userid is the PR creator. Resolves #171

### DIFF
--- a/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/trigger/check/NotUpdatedPRFilter.java
+++ b/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/trigger/check/NotUpdatedPRFilter.java
@@ -63,8 +63,8 @@ public class NotUpdatedPRFilter implements Predicate<GHPullRequest> {
             boolean updated = prUpd || issueUpd || headUpd;
 
             if (updated) {
-                LOGGER.info("Pull request #{} was updated at: {} by {}",
-                        localPR.getNumber(), localPR.getPrUpdatedAt(), localPR.getUserLogin());
+                LOGGER.info("Pull request #{} was created by {}, last updated: {}",
+                        localPR.getNumber(), localPR.getUserLogin(), localPR.getPrUpdatedAt());
             }
 
             return updated;


### PR DESCRIPTION
Change log message to be clear that the userid in the message is
the PR creator, not necessarily the user who made the last update.

I built and tested it on my server. The message now looks like this:

Pull request #8 was created by dvalliere, last updated: Sun Nov 20 19:51:15 EST 2016

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kostyasha/github-integration-plugin/173)
<!-- Reviewable:end -->
