### PR TITLE
- check the last commit's message if repo isn't known

### DIFF
--- a/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/events/impl/GitHubBranchCommitEvent.java
+++ b/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/events/impl/GitHubBranchCommitEvent.java
@@ -4,12 +4,10 @@ import com.github.kostyasha.github.integration.branch.GitHubBranch;
 import com.github.kostyasha.github.integration.branch.GitHubBranchCause;
 import com.github.kostyasha.github.integration.branch.GitHubBranchRepository;
 import com.github.kostyasha.github.integration.branch.GitHubBranchTrigger;
-import com.github.kostyasha.github.integration.branch.events.impl.commitchecks.GitHubBranchCommitCheck;
-import com.github.kostyasha.github.integration.branch.events.impl.commitchecks.GitHubBranchCommitCheckDescriptor;
 import com.github.kostyasha.github.integration.branch.events.GitHubBranchEvent;
 import com.github.kostyasha.github.integration.branch.events.GitHubBranchEventDescriptor;
-
-import static org.jenkinsci.plugins.github.pullrequest.utils.ObjectsUtil.isNull;
+import com.github.kostyasha.github.integration.branch.events.impl.commitchecks.GitHubBranchCommitCheck;
+import com.github.kostyasha.github.integration.branch.events.impl.commitchecks.GitHubBranchCommitCheckDescriptor;
 
 import hudson.Extension;
 import hudson.model.TaskListener;
@@ -19,6 +17,7 @@ import net.sf.json.JSONObject;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.github.GHBranch;
+import org.kohsuke.github.GHCommit;
 import org.kohsuke.github.GHCompare;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
@@ -33,14 +32,17 @@ import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.jenkinsci.plugins.github.pullrequest.utils.ObjectsUtil.isNull;
+
 /**
- * This branch event acts as a wrapper around checks that can be performed against commit data that requires
- * an additional round trip to GitHub to retrieve.
+ * This branch event acts as a wrapper around checks that can be performed against commit data that requires an additional round trip to
+ * GitHub to retrieve.
  * <p>
- * Commit data is retrieved and then passed to each implementing instance of <code>GitHubBranchCommitCheck</code>
- * to determine information about the commit should trigger a build.
+ * Commit data is retrieved and then passed to each implementing instance of <code>GitHubBranchCommitCheck</code> to determine information
+ * about the commit should trigger a build.
  * </p>
  *
  * @author Kanstantsin Shautsou
@@ -67,32 +69,20 @@ public class GitHubBranchCommitEvent extends GitHubBranchEvent {
 
     @Override
     public GitHubBranchCause check(GitHubBranchTrigger trigger, GHBranch remoteBranch, @CheckForNull GitHubBranch localBranch,
-                                   GitHubBranchRepository localRepo, TaskListener listener)
-            throws IOException {
-        final PrintStream lloger = listener.getLogger();
+            GitHubBranchRepository localRepo, TaskListener listener)
+        throws IOException {
+        final PrintStream logger = listener.getLogger();
+        Function<GitHubBranchCommitCheck, GitHubBranchCause> function;
 
         if (localBranch == null) {
-            LOG.debug("First build of branch '%s' detected, skipping check.", remoteBranch.getName());
-            lloger.println("First build of branch '" + remoteBranch.getName() + "' detected, skipping check.");
-            return null;
+            GHCommit commit = getLastCommit(remoteBranch);
+            function = event -> event.check(remoteBranch, localRepo, commit);
+        } else {
+            GHCompare.Commit[] commits = getComparedCommits(localBranch, remoteBranch);
+            function = event -> event.check(remoteBranch, localRepo, commits);
         }
 
-        GHCompare.Commit[] commits = getComparedCommits(localBranch, remoteBranch);
-        List<GitHubBranchCause> causes = checks.stream()
-                .map(event -> event.check(remoteBranch, localRepo, commits))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
-
-        String name = remoteBranch.getName();
-        if (causes.isEmpty()) {
-            LOG.debug("Commits for branch [{}] had no effect, not triggering run.", name);
-            return null;
-        }
-
-        GitHubBranchCause cause = causes.get(0);
-        LOG.info("Building branch [{}] skipped due to commit check: {}", name, cause.getReason());
-
-        return cause;
+        return check(remoteBranch, function, logger);
     }
 
     // visible for testing to avoid complex mocking
@@ -106,6 +96,11 @@ public class GitHubBranchCommitEvent extends GitHubBranchEvent {
                 .getCommits();
     }
 
+    // visible for testing to avoid complex mocking
+    GHCommit getLastCommit(GHBranch remoteBranch) throws IOException {
+        return remoteBranch.getOwner().getCommit(remoteBranch.getSHA1());
+    }
+
     @Nonnull
     public List<GitHubBranchCommitCheck> getChecks() {
         if (isNull(checks)) {
@@ -116,6 +111,26 @@ public class GitHubBranchCommitEvent extends GitHubBranchEvent {
 
     public void setChecks(List<GitHubBranchCommitCheck> checks) {
         this.checks = checks;
+    }
+
+    private GitHubBranchCause check(GHBranch remoteBranch, Function<GitHubBranchCommitCheck, GitHubBranchCause> function,
+            PrintStream logger) {
+        List<GitHubBranchCause> causes = checks.stream()
+                .map(function::apply)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        String name = remoteBranch.getName();
+        if (causes.isEmpty()) {
+            LOG.debug("Commits for branch [{}] had no effect, not triggering run.", name);
+            return null;
+        }
+
+        GitHubBranchCause cause = causes.get(0);
+        LOG.info("Building branch [{}] skipped due to commit check: {}", name, cause.getReason());
+        logger.printf("Building branch [%s] skipped due to commit check: %s", cause.getReason());
+
+        return cause;
     }
 
     @Extension

--- a/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/events/impl/commitchecks/GitHubBranchCommitCheck.java
+++ b/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/events/impl/commitchecks/GitHubBranchCommitCheck.java
@@ -2,19 +2,26 @@ package com.github.kostyasha.github.integration.branch.events.impl.commitchecks;
 
 import com.github.kostyasha.github.integration.branch.GitHubBranchCause;
 import com.github.kostyasha.github.integration.branch.GitHubBranchRepository;
-
 import com.github.kostyasha.github.integration.branch.events.impl.GitHubBranchCommitEvent;
+
 import hudson.ExtensionPoint;
 import hudson.model.AbstractDescribableImpl;
 
 import org.kohsuke.github.GHBranch;
+import org.kohsuke.github.GHCommit;
 import org.kohsuke.github.GHCompare.Commit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
 
 /**
  * @see GitHubBranchCommitEvent
  */
 public abstract class GitHubBranchCommitCheck extends AbstractDescribableImpl<GitHubBranchCommitCheck>
         implements ExtensionPoint {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GitHubBranchCommitCheck.class);
 
     @Override
     public GitHubBranchCommitCheckDescriptor getDescriptor() {
@@ -30,4 +37,27 @@ public abstract class GitHubBranchCommitCheck extends AbstractDescribableImpl<Gi
      * @return <code>GitHubBranchCause</code> instance indicating if the build should be skipped, <code>null</code> otherwise.
      */
     public abstract GitHubBranchCause check(GHBranch remoteBranch, GitHubBranchRepository localRepo, Commit[] commits);
+
+    /**
+     * Check used to determine if some associated commit property, such as the commit message, should prevent a build from being triggered.
+     * <p>
+     * This method is called when the repository is not yet known to the plugin.
+     * </p>
+     *
+     * @param remoteBranch current branch state from GH.
+     * @param localRepo local repository state.
+     * @param commit last commit in the remote repository.
+     * @return <code>GitHubBranchCause</code> instance indicating if the build should be skipped, <code>null</code> otherwise.
+     */
+    public GitHubBranchCause check(GHBranch remoteBranch, GitHubBranchRepository localRepo, GHCommit commit) {
+        try {
+            return doCheck(remoteBranch, localRepo, commit);
+        } catch (IOException e) {
+            LOG.error("Failed to check commit for hash [{}]", commit.getSHA1(), e);
+            return new GitHubBranchCause(remoteBranch, localRepo, e.getMessage(), true);
+        }
+    }
+
+    protected abstract GitHubBranchCause doCheck(GHBranch remoteBranch, GitHubBranchRepository localRepo, GHCommit commit)
+        throws IOException;
 }

--- a/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/events/impl/commitchecks/impl/GitHubBranchCommitMessageCheck.java
+++ b/github-pullrequest-plugin/src/main/java/com/github/kostyasha/github/integration/branch/events/impl/commitchecks/impl/GitHubBranchCommitMessageCheck.java
@@ -4,9 +4,12 @@ import com.github.kostyasha.github.integration.branch.GitHubBranchCause;
 import com.github.kostyasha.github.integration.branch.GitHubBranchRepository;
 import com.github.kostyasha.github.integration.branch.events.impl.commitchecks.GitHubBranchCommitCheck;
 import com.github.kostyasha.github.integration.branch.events.impl.commitchecks.GitHubBranchCommitCheckDescriptor;
+
 import hudson.Extension;
 import hudson.ExtensionPoint;
+
 import org.kohsuke.github.GHBranch;
+import org.kohsuke.github.GHCommit;
 import org.kohsuke.github.GHCompare.Commit;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -15,9 +18,12 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.CheckForNull;
 
+import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
@@ -39,23 +45,18 @@ public class GitHubBranchCommitMessageCheck extends GitHubBranchCommitCheck impl
     }
 
     @Override
+    public GitHubBranchCause doCheck(GHBranch remoteBranch, GitHubBranchRepository localRepo, GHCommit commit) throws IOException {
+        List<String> messages = Arrays.asList(commit.getCommitShortInfo().getMessage());
+        return check(remoteBranch, localRepo, () -> messages);
+    }
+
+    @Override
     public GitHubBranchCause check(GHBranch remoteBranch, GitHubBranchRepository localRepo, Commit[] commits) {
-        String name = remoteBranch.getName();
-        if (matchCriteria.isEmpty()) {
-            LOG.warn("Commit message event added but no match criteria set, all commits are allowed.");
-            return null;
-        }
-
-        List<String> messages = Stream.of(commits)
-                .map(commit -> commit.getCommit().getMessage())
-                .collect(Collectors.toList());
-
-        if (commitsAreAllowed(messages)) {
-            LOG.debug("Commit messages {} for branch [{}] allowed, commit ignored.", messages, name);
-            return null;
-        }
-
-        return toCause(remoteBranch, localRepo, true, "Commit messages %s for branch [%s] not allowed by check.", messages, name);
+        return check(remoteBranch, localRepo, () -> {
+            return Stream.of(commits)
+                    .map(commit -> commit.getCommit().getMessage())
+                    .collect(Collectors.toList());
+        });
     }
 
     public String getMatchCriteria() {
@@ -77,6 +78,22 @@ public class GitHubBranchCommitMessageCheck extends GitHubBranchCommitCheck impl
         this.matchCriteria = Stream.of(matchCriteria
                 .split(LINE_SEPARATOR))
                 .collect(Collectors.toSet());
+    }
+
+    private <T> GitHubBranchCause check(GHBranch remoteBranch, GitHubBranchRepository localRepo, Supplier<List<String>> supplier) {
+        if (matchCriteria.isEmpty()) {
+            LOG.warn("Commit message event added but no match criteria set, all commits are allowed.");
+            return null;
+        }
+
+        String name = remoteBranch.getName();
+        List<String> messages = supplier.get();
+        if (commitsAreAllowed(messages)) {
+            LOG.debug("Commit messages {} for branch [{}] allowed, commit ignored.", messages, name);
+            return null;
+        }
+
+        return toCause(remoteBranch, localRepo, true, "Commit messages %s for branch [%s] not allowed by check.", messages, name);
     }
 
     private boolean commitsAreAllowed(List<String> messages) {
@@ -117,7 +134,7 @@ public class GitHubBranchCommitMessageCheck extends GitHubBranchCommitCheck impl
     }
 
     private GitHubBranchCause toCause(GHBranch remoteBranch, GitHubBranchRepository localRepo, boolean skip, String message,
-                                      Object... args) {
+            Object... args) {
         return new GitHubBranchCause(remoteBranch, localRepo, String.format(message, args), skip);
     }
 


### PR DESCRIPTION
this change checks the message of the last commit in the remote repository if the plugin doesn't know about the branch yet, otherwise the plugin could trigger a build depending on what other criteria is set (in this case, `branch created`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kostyasha/github-integration-plugin/200)
<!-- Reviewable:end -->
