### PR TITLE
Add extra logging to NotUpdatedPRFilter when PR is not updated

### DIFF
--- a/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/trigger/check/NotUpdatedPRFilter.java
+++ b/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/trigger/check/NotUpdatedPRFilter.java
@@ -38,10 +38,9 @@ public class NotUpdatedPRFilter implements Predicate<GHPullRequest>, java.util.f
         @CheckForNull GitHubPRPullRequest localPR = localRepo.getPulls().get(remotePR.getNumber());
 
         if (!isUpdated(remotePR, localPR)) { // light check
-
-			String logMessage = String.format("PR [#%s %s] not changed", remotePR.getNumber(), remotePR.getTitle());
+            String logMessage = String.format("PR [#%s %s] not changed", remotePR.getNumber(), remotePR.getTitle());
             logger.getLogger().println(logMessage);
-			LOGGER.info(logMessage);
+            LOGGER.info(logMessage);
             return false;
         }
         return true;

--- a/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/trigger/check/NotUpdatedPRFilter.java
+++ b/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/trigger/check/NotUpdatedPRFilter.java
@@ -40,7 +40,7 @@ public class NotUpdatedPRFilter implements Predicate<GHPullRequest>, java.util.f
         if (!isUpdated(remotePR, localPR)) { // light check
             String logMessage = String.format("PR [#%s %s] not changed", remotePR.getNumber(), remotePR.getTitle());
             logger.getLogger().println(logMessage);
-            LOGGER.info(logMessage);
+            LOGGER.debug(logMessage);
             return false;
         }
         return true;

--- a/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/trigger/check/NotUpdatedPRFilter.java
+++ b/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/trigger/check/NotUpdatedPRFilter.java
@@ -38,7 +38,7 @@ public class NotUpdatedPRFilter implements Predicate<GHPullRequest>, java.util.f
         @CheckForNull GitHubPRPullRequest localPR = localRepo.getPulls().get(remotePR.getNumber());
 
         if (!isUpdated(remotePR, localPR)) { // light check
-		
+
 			String logMessage = String.format("PR [#%s %s] not changed", remotePR.getNumber(), remotePR.getTitle());
             logger.getLogger().println(logMessage);
 			LOGGER.info(logMessage);

--- a/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/trigger/check/NotUpdatedPRFilter.java
+++ b/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/trigger/check/NotUpdatedPRFilter.java
@@ -38,7 +38,10 @@ public class NotUpdatedPRFilter implements Predicate<GHPullRequest>, java.util.f
         @CheckForNull GitHubPRPullRequest localPR = localRepo.getPulls().get(remotePR.getNumber());
 
         if (!isUpdated(remotePR, localPR)) { // light check
-            logger.getLogger().println(String.format("PR [#%s %s] not changed", remotePR.getNumber(), remotePR.getTitle()));
+		
+			String logMessage = String.format("PR [#%s %s] not changed", remotePR.getNumber(), remotePR.getTitle());
+            logger.getLogger().println(logMessage);
+			LOGGER.info(logMessage);
             return false;
         }
         return true;


### PR DESCRIPTION
Currently, the `apply` method only logs to the TaskListener. With this change, it will also log to the
local `Logger`, so we can find the output in the main Jenkins logs. This will help with debugging issues
related to NotUpdatedPRFilter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kostyasha/github-integration-plugin/299)
<!-- Reviewable:end -->
