### PR TITLE
#347 Add two properties for comment author name and email

### DIFF
--- a/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/GitHubPRCause.java
+++ b/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/GitHubPRCause.java
@@ -52,6 +52,8 @@ public class GitHubPRCause extends GitHubCause<GitHubPRCause> {
 
     private String condRef;
     private String state;
+    private String commentAuthorName;
+    private String commentAuthorEmail;
     private String commentBody;
     private String commentBodyMatch;
 
@@ -164,6 +166,8 @@ public class GitHubPRCause extends GitHubCause<GitHubPRCause> {
         withTriggerSenderName(orig.getTriggerSenderEmail());
         withTriggerSenderEmail(orig.getTriggerSenderEmail());
         withBody(orig.getBody());
+        withCommentAuthorName(orig.getCommentAuthorName());
+        withCommentAuthorEmail(orig.getCommentAuthorEmail());
         withCommentBody(orig.getCommentBody());
         withCommentBodyMatch(orig.getCommentBodyMatch());
         withCommitAuthorName(orig.getCommitAuthorName());
@@ -282,6 +286,16 @@ public class GitHubPRCause extends GitHubCause<GitHubPRCause> {
         return this;
     }
 
+    public GitHubPRCause withCommentAuthorName(String commentAuthorName) {
+        this.commentAuthorName = commentAuthorName;
+        return this;
+    }
+
+    public GitHubPRCause withCommentAuthorEmail(String commentAuthorEmail) {
+        this.commentAuthorEmail = commentAuthorEmail;
+        return this;
+    }
+
     public GitHubPRCause withCommentBody(String commentBody) {
         this.commentBody = commentBody;
         return this;
@@ -366,6 +380,20 @@ public class GitHubPRCause extends GitHubCause<GitHubPRCause> {
     @NonNull
     public String getCondRef() {
         return condRef;
+    }
+
+    /**
+     * When trigger by comment, author of comment.
+     */
+    public String getCommentAuthorName() {
+        return commentAuthorName;
+    }
+
+    /**
+     * When trigger by comment, author email of comment.
+     */
+    public String getCommentAuthorEmail() {
+        return commentAuthorEmail;
     }
 
     /**

--- a/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/data/GitHubPREnv.java
+++ b/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/data/GitHubPREnv.java
@@ -30,6 +30,8 @@ public enum GitHubPREnv implements GitHubEnv<GitHubPRCause> {
     CAUSE_SKIP(GitHubPRCause::isSkip),
     NUMBER((Function<GitHubPRCause, String>) c -> String.valueOf(c.getNumber())),
     STATE(GitHubPRCause::getState),
+    COMMENT_AUTHOR_NAME(GitHubPRCause::getCommentAuthorName),
+    COMMENT_AUTHOR_EMAIL(GitHubPRCause::getCommentAuthorEmail),
     COMMENT_BODY(GitHubPRCause::getCommentBody),
     COMMENT_BODY_MATCH(GitHubPRCause::getCommentBodyMatch),
     LABELS((Function<GitHubPRCause, String>) c -> String.join(",", c.getLabels()));

--- a/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/events/impl/GitHubPRCommentEvent.java
+++ b/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/events/impl/GitHubPRCommentEvent.java
@@ -96,6 +96,8 @@ public class GitHubPRCommentEvent extends GitHubPREvent {
                     LOG.trace("Event matches comment '{}'", body);
                     cause = prDecisionContext.newCause("Comment matches to criteria.", false);
                     cause.withCommentBody(body);
+                    cause.withCommentAuthorName(issueComment.getUser().getName());
+                    cause.withCommentAuthorEmail(issueComment.getUser().getEmail());
                     if (matcher.groupCount() > 0) {
                         cause.withCommentBodyMatch(matcher.group(1));
                     }

--- a/github-pullrequest-plugin/src/test/java/org/jenkinsci/plugins/github/pullrequest/events/impl/GitHubPRCommentEventTest.java
+++ b/github-pullrequest-plugin/src/test/java/org/jenkinsci/plugins/github/pullrequest/events/impl/GitHubPRCommentEventTest.java
@@ -122,7 +122,7 @@ public class GitHubPRCommentEventTest {
                 );
 
         assertEquals(cause.getCommentAuthorName(), "commentOwnerName");
-        assertEquals(cause.getCommentAuthorEmail(), "commentOwnerName@email.com");
+        assertEquals(cause.getCommentAuthorEmail(), "commentOwner@email.com");
         assertThat(cause.getCommentBody(), is(body));
         assertThat(cause.getCommentBodyMatch(), is("foo, bar"));
         assertNotNull(cause);
@@ -161,7 +161,7 @@ public class GitHubPRCommentEventTest {
                         .build()
                 );
         assertEquals(cause.getCommentAuthorName(), "commentOwnerName");
-        assertEquals(cause.getCommentAuthorEmail(), "commentOwnerName@email.com");
+        assertEquals(cause.getCommentAuthorEmail(), "commentOwner@email.com");
         assertNotEquals(cause.getCommentAuthorName(), "commentOwnerName2");
         assertNotEquals(cause.getCommentAuthorEmail(), "commentOwner2@email.com");
         assertNotNull(cause);

--- a/github-pullrequest-plugin/src/test/java/org/jenkinsci/plugins/github/pullrequest/events/impl/GitHubPRCommentEventTest.java
+++ b/github-pullrequest-plugin/src/test/java/org/jenkinsci/plugins/github/pullrequest/events/impl/GitHubPRCommentEventTest.java
@@ -28,13 +28,12 @@ import static com.github.kostyasha.github.integration.generic.GitHubPRDecisionCo
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.isNotNull;
-import static org.mockito.Matchers.notNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -68,6 +67,10 @@ public class GitHubPRCommentEventTest {
     @Mock
     private GitHubPRTrigger trigger;
 
+    @Mock
+    private GHUser author;
+    @Mock
+    private GHUser author2;
     @Mock
     private GHIssueComment comment;
     @Mock
@@ -118,6 +121,8 @@ public class GitHubPRCommentEventTest {
                         .build()
                 );
 
+        assertEquals(cause.getCommentAuthorName(), "commentOwnerName");
+        assertEquals(cause.getCommentAuthorEmail(), "commentOwnerName@email.com");
         assertThat(cause.getCommentBody(), is(body));
         assertThat(cause.getCommentBodyMatch(), is("foo, bar"));
         assertNotNull(cause);
@@ -135,8 +140,11 @@ public class GitHubPRCommentEventTest {
         when(comment.getCreatedAt()).thenReturn(new Date());
 
         final String body2 = "no matching in second comment";
+        when(comment2.getUser()).thenReturn(author2);
         when(comment2.getBody()).thenReturn(body2);
         when(comment2.getCreatedAt()).thenReturn(new Date());
+        when(author2.getName()).thenReturn("commentOwnerName2");
+        when(author2.getEmail()).thenReturn("commentOwner2@email.com");
 
 
         final ArrayList<GHIssueComment> ghIssueComments = new ArrayList<>();
@@ -152,7 +160,11 @@ public class GitHubPRCommentEventTest {
                         .withListener(listener)
                         .build()
                 );
-        assertThat(cause, notNullValue());
+        assertEquals(cause.getCommentAuthorName(), "commentOwnerName");
+        assertEquals(cause.getCommentAuthorEmail(), "commentOwnerName@email.com");
+        assertNotEquals(cause.getCommentAuthorName(), "commentOwnerName2");
+        assertNotEquals(cause.getCommentAuthorEmail(), "commentOwner2@email.com");
+        assertNotNull(cause);
         assertThat(cause.getCommentBody(), is(body));
         assertThat(cause.getCommentBodyMatch(), is("foo, bar"));
     }
@@ -196,6 +208,8 @@ public class GitHubPRCommentEventTest {
                         .build()
                 ); // localPR is null
 
+        assertEquals(cause.getCommentAuthorName(), "commentOwnerName");
+        assertEquals(cause.getCommentAuthorEmail(), "commentOwner@email.com");
         assertThat(cause.getCommentBody(), is(body));
         assertThat(cause.getCommentBodyMatch(), is("foo, bar"));
         assertNotNull(cause);
@@ -209,6 +223,9 @@ public class GitHubPRCommentEventTest {
         when(repository.getIssue(anyInt())).thenReturn(issue);
         when(repository.getOwnerName()).thenReturn("ownerName");
         when(listener.getLogger()).thenReturn(logger);
+        when(comment.getUser()).thenReturn(author);
+        when(author.getName()).thenReturn("commentOwnerName");
+        when(author.getEmail()).thenReturn("commentOwner@email.com");
     }
 
     private void causeCreationExpectations() throws IOException {

--- a/github-pullrequest-plugin/src/test/java/org/jenkinsci/plugins/github/pullrequest/events/impl/GitHubPRCommentEventTest.java
+++ b/github-pullrequest-plugin/src/test/java/org/jenkinsci/plugins/github/pullrequest/events/impl/GitHubPRCommentEventTest.java
@@ -28,9 +28,8 @@ import static com.github.kostyasha.github.integration.generic.GitHubPRDecisionCo
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.anyInt;
@@ -121,8 +120,8 @@ public class GitHubPRCommentEventTest {
                         .build()
                 );
 
-        assertEquals(cause.getCommentAuthorName(), "commentOwnerName");
-        assertEquals(cause.getCommentAuthorEmail(), "commentOwner@email.com");
+        assertThat(cause.getCommentAuthorName(), is("commentOwnerName"));
+        assertThat(cause.getCommentAuthorEmail(), is("commentOwner@email.com"));
         assertThat(cause.getCommentBody(), is(body));
         assertThat(cause.getCommentBodyMatch(), is("foo, bar"));
         assertNotNull(cause);
@@ -160,10 +159,10 @@ public class GitHubPRCommentEventTest {
                         .withListener(listener)
                         .build()
                 );
-        assertEquals(cause.getCommentAuthorName(), "commentOwnerName");
-        assertEquals(cause.getCommentAuthorEmail(), "commentOwner@email.com");
-        assertNotEquals(cause.getCommentAuthorName(), "commentOwnerName2");
-        assertNotEquals(cause.getCommentAuthorEmail(), "commentOwner2@email.com");
+        assertThat(cause.getCommentAuthorName(), is("commentOwnerName"));
+        assertThat(cause.getCommentAuthorEmail(), is("commentOwner@email.com"));
+        assertThat(cause.getCommentAuthorName(), not("commentOwnerName2"));
+        assertThat(cause.getCommentAuthorEmail(), not("commentOwner2@email.com"));
         assertNotNull(cause);
         assertThat(cause.getCommentBody(), is(body));
         assertThat(cause.getCommentBodyMatch(), is("foo, bar"));
@@ -208,8 +207,8 @@ public class GitHubPRCommentEventTest {
                         .build()
                 ); // localPR is null
 
-        assertEquals(cause.getCommentAuthorName(), "commentOwnerName");
-        assertEquals(cause.getCommentAuthorEmail(), "commentOwner@email.com");
+        assertThat(cause.getCommentAuthorName(), is("commentOwnerName"));
+        assertThat(cause.getCommentAuthorEmail(), is("commentOwner@email.com"));
         assertThat(cause.getCommentBody(), is(body));
         assertThat(cause.getCommentBodyMatch(), is("foo, bar"));
         assertNotNull(cause);


### PR DESCRIPTION
Added 2 new properties, which are similar with the COMMIT and TRIGGER equivalents

- GITHUB_PR_COMMENT_AUTHOR_NAME
- GITHUB_PR_COMMENT_AUTHOR_EMAIL

This can help if the comment owner is a privileged user (eg: Manager)
Which can be different than the PR owner or commit owner.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kostyasha/github-integration-plugin/348)
<!-- Reviewable:end -->
