### PR TITLE
Document https:// protocol, not git:// protocol

### DIFF
--- a/docs/Configuration.adoc
+++ b/docs/Configuration.adoc
@@ -67,5 +67,5 @@ url `${GITHUB_REPO_GIT_URL}`, branchspec `${GITHUB_BRANCH_NAME}`.
 - `GITHUB_BRANCH_CAUSE_SKIP` - `true` or `false`
 
 ===== Specific for repo:
-- `GITHUB_REPO_GIT_URL` - `git://github.com/KostyaSha-org/test-branches.git`
+- `GITHUB_REPO_GIT_URL` - `https://github.com/KostyaSha-org/test-branches.git`
 - `GITHUB_REPO_SSH_URL` - `git@github.com:KostyaSha-org/test-branches.git`


### PR DESCRIPTION
GitHub has blocked the unencrypted git protocol

https://github.blog/2021-09-01-improving-git-protocol-security-github/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/KostyaSha/github-integration-plugin/375)
<!-- Reviewable:end -->
