### PR TITLE
Replace Prototype.js with native JavaScript

### DIFF
--- a/github-pullrequest-plugin/src/main/webapp/scripts/featureButton.js
+++ b/github-pullrequest-plugin/src/main/webapp/scripts/featureButton.js
@@ -1,10 +1,12 @@
 function callFeature(button, answerPlaceId, parameters) {
-    new Ajax.Request(button.action, {
+    fetch(button.action, {
         method: "post",
-        parameters: parameters,
-        onComplete: function (rsp) {
-            answerPlaceId.innerHTML = rsp.responseText;
-        }
+        headers: crumb.wrap({}),
+        body: new URLSearchParams(parameters),
+    }).then(rsp => {
+        rsp.text().then((responseText) => {
+            answerPlaceId.innerHTML = responseText;
+        });
     });
     return false;
 }


### PR DESCRIPTION
See [JENKINS-70906](https://issues.jenkins.io/browse/JENKINS-70906). Jenkins core currently uses [Prototype 1.7](https://github.com/prototypejs/prototype/releases/tag/1.7), released on November 15, 2010. The latest version is [Prototype 1.7.3](https://github.com/prototypejs/prototype/releases/tag/1.7.3), released on September 22, 2015. When an attempt was made to upgrade to 1.7.3 in 2018 in [JENKINS-49319](https://issues.jenkins.io/browse/JENKINS-49319), the change had to be reverted. Since this library has been unmaintained for the past 8 years, this PR removes any usages of it in favor of native JavaScript APIs. To test this, I installed this plugin on a custom build of Jenkins that had Prototype ripped out (a local project branch), clicked on the "Run GH PR Trigger" button, and stepped through the changed lines in the browser's debugger to ensure the code was still working as before.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/KostyaSha/github-integration-plugin/379)
<!-- Reviewable:end -->
