### PR TITLE
Upgrade plugin parent POM to latest version

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.4</version>
+    <version>1.6</version>
   </extension>
 </extensions>

--- a/github-pullrequest-plugin/pom.xml
+++ b/github-pullrequest-plugin/pom.xml
@@ -40,8 +40,6 @@
     </scm>
 
     <properties>
-        <mockito.version>3.12.4</mockito.version>
-        <powermock.version>2.0.9</powermock.version>
         <excluded.tests>**/its/*.java</excluded.tests>
         <access-modifier-checker.skip>true</access-modifier-checker.skip>
         <spotbugs.skip>true</spotbugs.skip>
@@ -65,8 +63,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.346.x</artifactId>
-                <version>1763.v092b_8980a_f5e</version>
+                <artifactId>bom-2.361.x</artifactId>
+                <version>2081.v85885a_d2e5c5</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -238,27 +236,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-core</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/github-pullrequest-plugin/src/test/java/org/jenkinsci/plugins/github/pullrequest/events/impl/GitHubPRDescriptionEventTest.java
+++ b/github-pullrequest-plugin/src/test/java/org/jenkinsci/plugins/github/pullrequest/events/impl/GitHubPRDescriptionEventTest.java
@@ -1,7 +1,7 @@
 package org.jenkinsci.plugins.github.pullrequest.events.impl;
 
 import hudson.model.FreeStyleProject;
-import hudson.model.Job;
+import hudson.model.ItemGroup;
 import hudson.model.TaskListener;
 import org.jenkinsci.plugins.github.pullrequest.GitHubPRCause;
 import org.jenkinsci.plugins.github.pullrequest.GitHubPRTrigger;
@@ -14,12 +14,10 @@ import org.kohsuke.github.GHPullRequest;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GHUser;
 import org.mockito.Mock;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.io.PrintStream;
-import java.util.Date;
 
 import static com.github.kostyasha.github.integration.generic.GitHubPRDecisionContext.newGitHubPRDecisionContext;
 import static org.hamcrest.Matchers.nullValue;
@@ -33,16 +31,15 @@ import static org.mockito.Mockito.when;
 /**
  * @author Kanstantsin Shautsou
  */
-@PrepareForTest(Job.class)
-@RunWith(PowerMockRunner.class)
+@RunWith(MockitoJUnitRunner.class)
 public class GitHubPRDescriptionEventTest {
     @Mock
-    private FreeStyleProject job;
+    private ItemGroup parent;
 
     @Mock
     private GHPullRequest remotePr;
 
-    @Mock
+    @Mock(lenient = true)
     private GHRepository repository;
     @Mock
     private GHIssue issue;
@@ -62,7 +59,6 @@ public class GitHubPRDescriptionEventTest {
 
         when(listener.getLogger()).thenReturn(logger);
 
-        when(issue.getCreatedAt()).thenReturn(new Date());
         when(remotePr.getBody()).thenReturn("must skip ci body");
 
         GitHubPRCause cause = new GitHubPRDescriptionEvent(".*[skip ci].*")
@@ -84,7 +80,6 @@ public class GitHubPRDescriptionEventTest {
 
         when(listener.getLogger()).thenReturn(logger);
 
-        when(issue.getCreatedAt()).thenReturn(new Date());
         when(remotePr.getBody()).thenReturn("unmatched comment");
 
         GitHubPRCause cause = new GitHubPRDescriptionEvent(".*skip ci.*")
@@ -99,9 +94,10 @@ public class GitHubPRDescriptionEventTest {
     }
 
     private void commonExpectations() throws IOException {
-        when(job.getFullName()).thenReturn("Full job name");
+        when(parent.getFullName()).thenReturn("Full job name");
 
-        when(trigger.getJob()).thenReturn((Job) job);
+        FreeStyleProject p = new FreeStyleProject(parent, "p");
+        when(trigger.getJob()).thenReturn(p);
 
         when(remotePr.getState()).thenReturn(GHIssueState.OPEN);
         when(remotePr.getRepository()).thenReturn(repository);

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.43.1</version>
+        <version>4.63</version>
         <relativePath />
     </parent>
 
@@ -34,7 +34,7 @@
     <properties>
         <revision>0.5.1</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.346.3</jenkins.version>
+        <jenkins.version>2.361.4</jenkins.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
Plugin parent POM [4.58](https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.58) contains an contains an update to support the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) in the [HtmlUnit](https://htmlunit.org/) browser used by the test harness, which is needed when using the Fetch API rather than Prototype. This PR upgrades this plugin to the latest plugin parent POM. Since the latest plugin parent POM requires Java 11, this PR also increases the Jenkins baseline to 2.361.x, which is Java 11 only. Since PowerMock does not work on Java 11, this PR also migrates PowerMock usages to Mockito. To test this PR, I successfully ran `mvn clean verify` in both Java 11 and Java 17.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/KostyaSha/github-integration-plugin/380)
<!-- Reviewable:end -->
