### PR TITLE
Use GitHub readme as documentation entry point

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -13,6 +13,10 @@ Provides `GitHub Pull Request` and `GitHub Branch` triggers
 
 link:/docs[docs subdirectory]
 
+== Version history
+
+Please refer to link:/CHANGELOG.md[the changelog].
+
 == Disclaimer
 
 * Backward compatibility may be broken in any time. (But wasn't in the last year and kept when it possible)

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <name>GitHub Integration Parent</name>
     <description>GitHub Integration Parent Module</description>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/GitHub+Integration+Plugin</url>
+    <url>https://github.com/jenkinsci/github-integration-plugin</url>
 
     <developers>
         <developer>


### PR DESCRIPTION
This PR is part of the effort to move docs from the wiki to GitHub.

The docs URL must be in jenkinsci org to work properly -- because https://github.com/jenkinsci/github-integration-plugin redirects here I hope it's OK.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/KostyaSha/github-integration-plugin/381)
<!-- Reviewable:end -->
