### PR TITLE
Add missing `application/x-www-form-urlencoded` header

### DIFF
--- a/github-pullrequest-plugin/src/main/webapp/scripts/featureButton.js
+++ b/github-pullrequest-plugin/src/main/webapp/scripts/featureButton.js
@@ -1,7 +1,9 @@
 function callFeature(button, answerPlaceId, parameters) {
     fetch(button.action, {
         method: "post",
-        headers: crumb.wrap({}),
+        headers: crumb.wrap({
+          "Content-Type": "application/x-www-form-urlencoded",
+        }),
         body: new URLSearchParams(parameters),
     }).then(rsp => {
         rsp.text().then((responseText) => {


### PR DESCRIPTION
See https://github.com/jenkinsci/jenkins/pull/8278. Not strictly necessary, and there is no user-facing issue here, but this PR is done as a code cleanup and to create a consistent coding style throughout the Jenkins project.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/KostyaSha/github-integration-plugin/382)
<!-- Reviewable:end -->
