### PR TITLE
Use GitHub as source of documentation

### DIFF
--- a/github-pullrequest-plugin/pom.xml
+++ b/github-pullrequest-plugin/pom.xml
@@ -15,7 +15,7 @@
 
     <name>GitHub Integration Plugin</name>
     <description>GitHub Integration Plugin for Jenkins</description>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/GitHub+Integration+Plugin</url>
+    <url>https://github.com/jenkinsci/github-integration-plugin</url>
     <licenses>
         <license>
             <name>MIT License</name>


### PR DESCRIPTION
Follow-up for https://github.com/KostyaSha/github-integration-plugin/pull/381 (didn't notice there are 2 poms)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/KostyaSha/github-integration-plugin/387)
<!-- Reviewable:end -->
