### PR TITLE
fix: fix nullpointerexception when body is null

### DIFF
--- a/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/events/impl/GitHubPRDescriptionEvent.java
+++ b/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/events/impl/GitHubPRDescriptionEvent.java
@@ -55,7 +55,7 @@ public class GitHubPRDescriptionEvent extends GitHubPREvent {
 
         GitHubPRCause cause = null;
 
-        String pullRequestBody = remotePR.getBody().trim();
+        String pullRequestBody = remotePR.getBody() != null ? remotePR.getBody().trim() : "";
         LOG.debug("Job: '{}', trigger event: '{}', body for test: '{}'",
                 fullName,
                 DISPLAY_NAME,

--- a/github-pullrequest-plugin/src/test/java/org/jenkinsci/plugins/github/pullrequest/events/impl/GitHubPRDescriptionEventTest.java
+++ b/github-pullrequest-plugin/src/test/java/org/jenkinsci/plugins/github/pullrequest/events/impl/GitHubPRDescriptionEventTest.java
@@ -110,7 +110,6 @@ public class GitHubPRDescriptionEventTest {
                         .build()
                 );
 
-        assertNotNull(cause);
         assertThat(cause, nullValue());
     }
 

--- a/github-pullrequest-plugin/src/test/java/org/jenkinsci/plugins/github/pullrequest/events/impl/GitHubPRDescriptionEventTest.java
+++ b/github-pullrequest-plugin/src/test/java/org/jenkinsci/plugins/github/pullrequest/events/impl/GitHubPRDescriptionEventTest.java
@@ -74,7 +74,7 @@ public class GitHubPRDescriptionEventTest {
     }
 
     @Test
-    public void skipDescriptionNotExist() throws IOException {
+    public void skipDescriptionExistNotMatch() throws IOException {
         commonExpectations();
         causeCreationExpectations();
 
@@ -90,6 +90,27 @@ public class GitHubPRDescriptionEventTest {
                         .build()
                 );
 
+        assertThat(cause, nullValue());
+    }
+
+    @Test
+    public void skipDescriptionNotExist() throws IOException {
+        commonExpectations();
+        causeCreationExpectations();
+
+        when(listener.getLogger()).thenReturn(logger);
+
+        when(remotePr.getBody()).thenReturn(null);
+
+        GitHubPRCause cause = new GitHubPRDescriptionEvent(".*[skip ci].*")
+                .check(newGitHubPRDecisionContext()
+                        .withPrTrigger(trigger)
+                        .withRemotePR(remotePr)
+                        .withListener(listener)
+                        .build()
+                );
+
+        assertNotNull(cause);
         assertThat(cause, nullValue());
     }
 


### PR DESCRIPTION
An exception will occur when the body is null (empty) and a pr description check is configured. This change will fall back to an empty string when the body is null (and thus empty).

Piece of webhook content:
```
{
  "action": "reopened",
  "number": 1144,
  "pull_request": {
    ...,
    "body": null,
    ...
  },
  ...
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/KostyaSha/github-integration-plugin/390)
<!-- Reviewable:end -->
